### PR TITLE
VM: Add toolchain required to compile xv6

### DIFF
--- a/scripts/images/3_prepare_image.sh
+++ b/scripts/images/3_prepare_image.sh
@@ -261,6 +261,11 @@ virt-customize --run-command 'ssh-keygen -A' -a "$IMAGE"
 # Enable network interface for Ubuntu cloud images (fallback)
 virt-customize --run-command 'echo "@reboot root dhclient" >> /etc/crontab' -a "$IMAGE"
 
+    
+# Install toolchain
+virt-customize --run-command 'apt-get install -y build-essential qemu-system-x86 clang-format-16 shellcheck gcc-multilib' -a "$IMAGE"
+    
+
 # Clean up package cache
 virt-customize --run-command 'apt-get autoremove -y && apt-get autoclean' -a "$IMAGE"
 


### PR DESCRIPTION
Added packages to VM that are required to compile xv6 
- build-essential
- qemu-system-x86
- clang-format-16
- shellcheck
- gcc-multilib